### PR TITLE
Feature/89 probably wood

### DIFF
--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -50,6 +50,7 @@ const Game: React.FC<Props> = ({ tokenId, token, nfts }) => {
     const [isMuted, setIsMuted] = useState(false);
     const [showMetrics, setShowMetrics] = useState(false);
     const [buildingDimensions, setBuildingDimensions] = useState<Record<string, BuildingDimensions>>({});
+    const [probablyWoodDimensions, setProbablyWoodDimensions] = useState<Record<string, BuildingDimensions>>({});
 
     const { 
         connected,
@@ -66,7 +67,7 @@ const Game: React.FC<Props> = ({ tokenId, token, nfts }) => {
         scareCityState,
         scanTrait
     } = useGameServer({
-        tokenId, token, onStaticActors: (actors: Actor[]) => setStaticActors(actors)
+        tokenId, token: token || '', onStaticActors: (actors: Actor[]) => setStaticActors(actors)
     });
 
     const [visibleMessages, setVisibleMessages] = useState<boolean[]>(
@@ -427,7 +428,13 @@ const Game: React.FC<Props> = ({ tokenId, token, nfts }) => {
                     </>
                 )}
                 {/* Probably Wood */}
-                <ProbablyWood left={5500} top={1440} />
+                <ProbablyWood 
+                    left={5500} 
+                    top={1440} 
+                    onElementDimensions={(dimensions: Record<string, BuildingDimensions>) => {
+                        setProbablyWoodDimensions(dimensions);
+                    }}
+                />
             </Styled.GameSpace>
             {position && (
                 <Minimap
@@ -440,6 +447,7 @@ const Game: React.FC<Props> = ({ tokenId, token, nfts }) => {
                     block={block}
                     scareCityDimensions={buildingDimensions}
                     scareCityState={scareCityState}
+                    probablyWoodDimensions={probablyWoodDimensions}
                 />
             )}
             {connected && player && (

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -18,6 +18,7 @@ import { WORLD_WIDTH, WORLD_HEIGHT } from '../../utils/coordinates';
 import { rivers, introMessages } from './components/Environment/set';
 import { isOnPath, isBlockedByRiver, isInStartBox, handleKeyDown, handleKeyUp } from "./utils";
 import Clock from './components/Clock/Clock';
+import ProbablyWood from "./components/ProbablyWood";
 import { ScareCity } from './components/ScareCity';
 import Hay from './components/Hay'
 
@@ -425,6 +426,8 @@ const Game: React.FC<Props> = ({ tokenId, token, nfts }) => {
                         ))}
                     </>
                 )}
+                {/* Probably Wood */}
+                <ProbablyWood left={5500} top={1440} />
             </Styled.GameSpace>
             {position && (
                 <Minimap

--- a/src/components/Game/components/ProbablyWood/ProbablyWood.style.ts
+++ b/src/components/Game/components/ProbablyWood/ProbablyWood.style.ts
@@ -1,0 +1,55 @@
+import styled from 'styled-components'
+import farouk from '/svg/31db13b10188de1afd6cff09cf65a0ae.svg'
+import forest from '/svg/forest.svg'
+
+
+export const Forest = styled.div`
+    width: 400px;
+    height: 400px;
+    z-index: 1;
+    position: absolute;
+    opacity: 0.8;
+    background-image: url(${forest});
+    background-size: contain;
+`
+
+export const Div = styled.div`
+    position: absolute;
+    width: 700px;
+    > div {
+        position: relative;
+         > ${Forest} {
+            &:first-of-type {
+                left: 340px;
+                top: 50px;
+            }
+        }
+        > h2 {
+            position: absolute;
+            opacity: 0.4;
+            font-size: 22px;
+            white-space: nowrap;
+            right: 0;
+        }
+        > p {
+            position: absolute;
+            top: 430px;
+            left: -140px;
+            width: 440px;
+            line-height: 32px;
+        }
+    }
+`
+
+export const Bear = styled.div`
+    left: 190px;
+    top: 100px;
+    width: 400px;
+    height: 400px;
+    z-index: 0;
+    position: absolute;
+    background-image: url(${farouk});
+    background-size: contain;
+   
+`
+

--- a/src/components/Game/components/ProbablyWood/ProbablyWood.tsx
+++ b/src/components/Game/components/ProbablyWood/ProbablyWood.tsx
@@ -1,0 +1,45 @@
+import * as Styled from './ProbablyWood.style'
+
+const ProbablyWood: React.FC<{ left: number, top: number }> = ({ left, top }) => {
+    return (
+        <Styled.Div style={{ left, top }}>
+            <div>
+                <h2>Probably Wood</h2>
+                <Styled.Forest />
+                <Styled.Forest />
+                <Styled.Bear />
+                <p>{'Sometimes, if you look closely, you can catch a glimpse of Kitty International\'s Two Bit Bear'}</p>
+            </div>
+        </Styled.Div>
+    )
+}
+
+export default ProbablyWood
+
+// entities.forest = {
+//     left: 3500, top: 1000, width: 500, height: 500, zIndex: 2, position: 'absolute', opacity: 0.8,
+//     backgroundImage: `url(${forest})`, backgroundSize: 'contain',
+//     renderer: <Forest />
+//   }
+//   entities.forest2 = {
+//     left: 410, top: 50, width: 400, height: 400, zIndex: 2, position: 'absolute', opacity: 0.8,
+//     backgroundImage: `url(${forest})`, backgroundSize: 'contain',
+//     renderer: <Forest />
+//   }
+
+//   entities.forestTitle = {
+//     left: 410, top: -20, width: 400, height: 400, zIndex: 2, position: 'absolute', opacity: 0.6,
+//     renderer: ({ left, top, width, height, zIndex, position, opacity }) => 
+//       <h2 style={{ left, top, width, height, zIndex, position, opacity }}>{'Probably Wood'}</h2>
+//   }
+
+//   entities.FarokhAokitheHappyBrownBear = {
+//     left: 280, top: 100, width: 400, height: 400, zIndex: 1, position: 'absolute',
+//     backgroundImage: `url(${farouk})`, backgroundSize: 'contain',
+//     renderer: ({ left, top, width, height, zIndex, position, backgroundImage, backgroundSize }) =>
+//       <div style={{ left, top, width, height, zIndex, position, backgroundImage, backgroundSize }}>
+//         <div style={{ marginTop: 360, marginLeft: 200, position, width: 400 }}>
+//           {'If you look closely sometimes you can get a glimpse of Kitty International\'s Two Bit Bear'}
+//         </div>
+//       </div>
+//   }

--- a/src/components/Game/components/ProbablyWood/ProbablyWood.tsx
+++ b/src/components/Game/components/ProbablyWood/ProbablyWood.tsx
@@ -1,13 +1,67 @@
 import * as Styled from './ProbablyWood.style'
+import { useEffect, useRef } from 'react';
 
-const ProbablyWood: React.FC<{ left: number, top: number }> = ({ left, top }) => {
+interface ProbablyWoodDimensions {
+    width: number;
+    height: number;
+    left: number;
+    top: number;
+}
+
+interface ProbablyWoodProps {
+    left: number;
+    top: number;
+    onElementDimensions?: (dimensions: Record<string, ProbablyWoodDimensions>) => void;
+}
+
+const ProbablyWood: React.FC<ProbablyWoodProps> = ({ left, top, onElementDimensions }) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const forest1Ref = useRef<HTMLDivElement>(null);
+    const forest2Ref = useRef<HTMLDivElement>(null);
+    const bearRef = useRef<HTMLDivElement>(null);
+    const measurementDone = useRef(false);
+
+    // Measure elements after they're rendered
+    useEffect(() => {
+        if (containerRef.current && forest1Ref.current && forest2Ref.current && bearRef.current && !measurementDone.current) {
+            const containerRect = containerRef.current.getBoundingClientRect();
+            const forest1Rect = forest1Ref.current.getBoundingClientRect();
+            const forest2Rect = forest2Ref.current.getBoundingClientRect();
+            const bearRect = bearRef.current.getBoundingClientRect();
+
+            const dimensions: Record<string, ProbablyWoodDimensions> = {
+                forest1: {
+                    width: forest1Rect.width,
+                    height: forest1Rect.height,
+                    left: left + (forest1Rect.left - containerRect.left),
+                    top: top + (forest1Rect.top - containerRect.top)
+                },
+                forest2: {
+                    width: forest2Rect.width,
+                    height: forest2Rect.height,
+                    left: left + (forest2Rect.left - containerRect.left),
+                    top: top + (forest2Rect.top - containerRect.top)
+                },
+                bear: {
+                    width: bearRect.width,
+                    height: bearRect.height,
+                    left: left + (bearRect.left - containerRect.left),
+                    top: top + (bearRect.top - containerRect.top)
+                }
+            };
+
+            onElementDimensions?.(dimensions);
+            measurementDone.current = true;
+        }
+    }, [left, top, onElementDimensions]);
+
     return (
-        <Styled.Div style={{ left, top }}>
+        <Styled.Div ref={containerRef} style={{ left, top }}>
             <div>
                 <h2>Probably Wood</h2>
-                <Styled.Forest />
-                <Styled.Forest />
-                <Styled.Bear />
+                <Styled.Forest ref={forest1Ref} />
+                <Styled.Forest ref={forest2Ref} className="second-forest" />
+                <Styled.Bear ref={bearRef} />
                 <p>{'Sometimes, if you look closely, you can catch a glimpse of Kitty International\'s Two Bit Bear'}</p>
             </div>
         </Styled.Div>

--- a/src/components/Game/components/ProbablyWood/index.ts
+++ b/src/components/Game/components/ProbablyWood/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ProbablyWood'

--- a/src/components/Game/components/ScareCity/ScareCity.tsx
+++ b/src/components/Game/components/ScareCity/ScareCity.tsx
@@ -103,14 +103,14 @@ const resultsRef = useRef<HTMLDivElement>(null);
             <Styled.Header>
                 <Styled.Ghost />
                 <h2>Scare City<span>Check if you're rare but don't get a scare!</span></h2>
-                <p>Stand in the doorway of all the skyscrapers but don't get spooked by a spooky ghost of death!</p>
+                <p>Run past the windows of all the skyscrapers but don't get spooked by a spooky ghost of death!</p>
                 {gameData.lastGame && (<p>
                     <> 
                         Last Game: 👻 Spooked {attributeTypes.filter(type => gameData.lastGame[type]?.foundBy).length} - {((attributeTypes.filter(type => gameData.lastGame[type]?.foundBy).length / 11) * 100).toFixed(2)}%
                         - 🥷🏼 Not scared: {gameData.lastGame.ghosts?.length || 0} - 🚜 Paid out: $HAY {gameData.lastGame.totalPaidOut}
                     </>
                 </p>)}
-                <p>This Game: finishes in {block && gameData.gameStart + gameData.gameLength - block.blocknumber} block{block && gameData.gameStart + gameData.gameLength - block.blocknumber === 1 ? ' ' : 's '}
+                <p>Current Game: finishes in {block && gameData.gameStart + gameData.gameLength - block.blocknumber} block{block && gameData.gameStart + gameData.gameLength - block.blocknumber === 1 ? ' ' : 's '}
                     - 👻 Spooked {attributeTypes.filter(type => gameData.attributes[type]?.foundBy).length} - 🥷🏼 Not scared: {gameData.ghosts?.length || 0}
                 </p>
             </Styled.Header>
@@ -149,7 +149,7 @@ const resultsRef = useRef<HTMLDivElement>(null);
                     </>
                 )}
                 
-                <h4>This Game</h4>
+                <h4>Current Game: ends in {block && gameData.gameStart + gameData.gameLength - block.blocknumber} block{block && gameData.gameStart + gameData.gameLength - block.blocknumber === 1 ? '' : 's'}</h4>
                 <ul>
                     <li>
                         👻 Spooked: {attributeTypes.filter(type => gameData.attributes[type]?.foundBy).length} - {((attributeTypes.filter(type => gameData.attributes[type]?.foundBy).length / 11) * 100).toFixed(2)}%
@@ -164,8 +164,6 @@ const resultsRef = useRef<HTMLDivElement>(null);
                     <li>🐎 All rewards have a "not scared" + 1 horse multiplier</li>
                     <li>🚜 <b>$HAY</b> is paid out in accordance with trait rarity</li>
                 </ul>
-
-                <h4>Next game starts: {block && gameData.gameStart + gameData.gameLength - block.blocknumber} blocks</h4>
             </Styled.Results>
         </Styled.Container>
     );

--- a/src/components/IntroModal/IntroModal.tsx
+++ b/src/components/IntroModal/IntroModal.tsx
@@ -1,8 +1,6 @@
-import { useState } from 'react'
 import * as Styled from './IntroModal.style'
 import Metamask from '../Metamask'
 import { getAssetPath } from '../../utils/assetPath';
-import { useGameServer } from '../Paddock/hooks/useGameServer';
 
 interface IntroModalProps {
     onSelectHorse: (horse: number) => void;  // Callback to select horse
@@ -35,8 +33,6 @@ const HorseSelect: React.FC<HorseSelectProps> = ({ nfts, onSelect }) => {
     );
 };
 
-import { BACKGROUND_MUSIC } from '../../audio';
-
 const IntroModal: React.FC<IntroModalProps> = ({
     onSelectHorse,
     handleSignIn,
@@ -46,13 +42,6 @@ const IntroModal: React.FC<IntroModalProps> = ({
     nfts,
     currentHorse
 }) => {
-    // Use socket passed from AppView
-    const handleStart = () => {
-        // Start playing music when entering paddock
-        //BACKGROUND_MUSIC.play()
-          //  .catch(error => console.error('Error playing audio:', error));
-        // onStart();
-    };
 
     // If we have a current horse, show it
     const selectedNft = currentHorse ? nfts.find(nft => nft.tokenId === currentHorse) : undefined;

--- a/src/components/Minimap/Minimap.tsx
+++ b/src/components/Minimap/Minimap.tsx
@@ -6,6 +6,7 @@ import { paths, rivers, raceElements, pond, issuesColumns } from '../../componen
 import { WORLD_WIDTH, WORLD_HEIGHT, MINIMAP_WIDTH, MINIMAP_HEIGHT } from '../../utils/coordinates';
 import { Actor } from '../../server/types/actor';
 import { CLOCK_DIMENSIONS } from '../Game/components/Clock/constants';
+import { getAssetPath } from 'src/utils/assetPath';
 
 const pulse = keyframes`
     0% { opacity: 0.6; }
@@ -51,7 +52,16 @@ interface MinimapProps {
         left: number;
         top: number;
     }>;
-    scareCityState?: Record<string, { foundBy: string | null }>;
+    scareCityState?: {
+        attributes: Record<string, { foundBy: string | null }>;
+        [key: string]: any;
+    };
+    probablyWoodDimensions?: Record<string, {
+        width: number;
+        height: number;
+        left: number;
+        top: number;
+    }>;
 }
 
 export const Minimap: React.FC<MinimapProps> = ({
@@ -62,7 +72,8 @@ export const Minimap: React.FC<MinimapProps> = ({
     nfts,
     block,
     scareCityDimensions,
-    scareCityState
+    scareCityState,
+    probablyWoodDimensions
 }) => {
     const [isPulsing, setIsPulsing] = useState(false);
 
@@ -200,12 +211,25 @@ export const Minimap: React.FC<MinimapProps> = ({
                                 width: dimensions.width,
                                 height: dimensions.height
                             }}
-                            isFound={!!scareCityState?.attributes[type]?.foundBy}
+                            isFound={!!scareCityState?.attributes?.[type]?.foundBy}
                         />
                     );
                 })}
 
                 {/* Probably Wood */}
+                {probablyWoodDimensions && Object.entries(probablyWoodDimensions).map(([type, dimensions]) => (
+                    <MinimapElement
+                        key={`probablyWood-${type}`}
+                        worldRect={{
+                            left: dimensions.left,
+                            top: dimensions.top,
+                            width: dimensions.width,
+                            height: dimensions.height
+                        }}
+                        backgroundImage={type.includes('forest') ? getAssetPath('svg/forest.svg') : getAssetPath('svg/31db13b10188de1afd6cff09cf65a0ae.svg')} // Green for forests, brown for bear
+                        opacity={0.7}
+                    />
+                ))}
 
                 {/* Only show player in play mode */}
                 {actors.map(actor => {

--- a/src/components/Minimap/Minimap.tsx
+++ b/src/components/Minimap/Minimap.tsx
@@ -205,6 +205,8 @@ export const Minimap: React.FC<MinimapProps> = ({
                     );
                 })}
 
+                {/* Probably Wood */}
+
                 {/* Only show player in play mode */}
                 {actors.map(actor => {
                     if (actor.type === 'player') {

--- a/src/components/Minimap/MinimapElement.tsx
+++ b/src/components/Minimap/MinimapElement.tsx
@@ -7,6 +7,8 @@ import { getSVG } from '../../utils/getImage';
 const StyledElement = styled.div`
     position: absolute;
     box-sizing: border-box;  /* Include border in size calculations */
+    background-repeat: no-repeat;
+    background-size: contain;
 `;
 
 export const MinimapElement: React.FC<{
@@ -14,8 +16,9 @@ export const MinimapElement: React.FC<{
     backgroundColor?: string;
     opacity?: number;
     borderRadius?: string;
+    backgroundImage?: string;
     className?: string;
-}> = ({ worldRect, backgroundColor, opacity, borderRadius, className }) => {
+}> = ({ worldRect, backgroundColor, backgroundImage, opacity, borderRadius, className }) => {
     const minimapRect = CoordinateTransformer.worldRectToMinimap(worldRect);
 
     return (
@@ -26,7 +29,8 @@ export const MinimapElement: React.FC<{
                 top: `${minimapRect.top}px`,
                 width: `${Math.max(minimapRect.width, 1)}px`,
                 height: `${Math.max(minimapRect.height, 1)}px`,
-                backgroundColor: backgroundColor || 'rgba(238, 238, 238, 0.5)',
+                backgroundColor: backgroundColor || 'transparent',
+                backgroundImage: backgroundImage ? `url(${backgroundImage})` : 'none',
                 opacity: opacity || 1,
                 borderRadius: borderRadius || '0'
             }}


### PR DESCRIPTION
## Modified the ProbablyWood component to:

- Add refs to measure the Forest and Bear elements
- Calculate their positions and dimensions
- Pass these dimensions to the Game component via a callback

<img width="1181" alt="Screenshot 2025-02-28 at 17 44 27" src="https://github.com/user-attachments/assets/d1350e38-f744-46c9-8714-c5e36fc51e24" />

## Updated the Game component to:

- Store the ProbablyWood dimensions in state
- Pass these dimensions to the Minimap component

## Updated the Minimap component to:

- Add probablyWoodDimensions to the props interface
- Render the ProbablyWood elements using the provided dimensions
- Use appropriate colors for the minimap representation (green for forests, brown for bear)

## This implementation follows a programmatic approach that:

- Maintains the proper proportions and positions of the elements
- Automatically updates if the layout of ProbablyWood changes
- Follows the same pattern as the ScareCity component for consistency

The forests and bear from ProbablyWood will now appear on the minimap with their proper positions and proportions. This approach is more maintainable than hardcoding positions and dimensions.


